### PR TITLE
fix: python version order and CI scaffold

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -29,17 +29,17 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: "${{ env.PYTHON_VERSION }}"
+          python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install poetry
-        run: pipx install poetry
+        run: pip install poetry
 
       - name: Determine dependencies
         run: poetry lock
 
       - uses: actions/setup-python@v4
         with:
-          python-version: "${{ env.PYTHON_VERSION }}"
+          python-version: ${{ env.PYTHON_VERSION }}
           cache: poetry
 
       - name: Install Dependencies using Poetry

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -5,6 +5,9 @@ on:
 
 name: release-please
 
+env:
+  PYTHON_VERSION: 3.11
+
 jobs:
   release-please:
     runs-on: ubuntu-latest
@@ -24,9 +27,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
-          python-version: "3.9"
+          python-version: "${{ env.PYTHON_VERSION }}"
 
       - name: Install poetry
         run: pipx install poetry
@@ -36,7 +39,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.9"
+          python-version: "${{ env.PYTHON_VERSION }}"
           cache: poetry
 
       - name: Install Dependencies using Poetry

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,17 +18,17 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: "${{ env.PYTHON_VERSION }}"
+          python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install poetry
-        run: pipx install poetry
+        run: pip install poetry
 
       - name: Determine dependencies
         run: poetry lock
 
       - uses: actions/setup-python@v4
         with:
-          python-version: "${{ env.PYTHON_VERSION }}"
+          python-version: ${{ env.PYTHON_VERSION }}
           cache: poetry
 
       - name: Install Dependencies using Poetry
@@ -45,17 +45,17 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: "${{ env.PYTHON_VERSION }}"
+          python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install poetry
-        run: pipx install poetry
+        run: pip install poetry
 
       - name: Determine dependencies
         run: poetry lock
 
       - uses: actions/setup-python@v4
         with:
-          python-version: "${{ env.PYTHON_VERSION }}"
+          python-version: ${{ env.PYTHON_VERSION }}
           cache: poetry
 
       - name: Install Dependencies using Poetry
@@ -71,17 +71,17 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: "${{ env.PYTHON_VERSION }}"
+          python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install poetry
-        run: pipx install poetry
+        run: pip install poetry
 
       - name: Determine dependencies
         run: poetry lock
 
       - uses: actions/setup-python@v4
         with:
-          python-version: "${{ env.PYTHON_VERSION }}"
+          python-version: ${{ env.PYTHON_VERSION }}
           cache: poetry
 
       - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,12 +6,19 @@ on:
       - main
   pull_request:
 
+env:
+  PYTHON_VERSION: 3.11
+
 jobs:
   formatting:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the code
         uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "${{ env.PYTHON_VERSION }}"
 
       - name: Install poetry
         run: pipx install poetry
@@ -21,7 +28,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.9"
+          python-version: "${{ env.PYTHON_VERSION }}"
           cache: poetry
 
       - name: Install Dependencies using Poetry
@@ -36,6 +43,10 @@ jobs:
       - name: Check out the code
         uses: actions/checkout@v3
 
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "${{ env.PYTHON_VERSION }}"
+
       - name: Install poetry
         run: pipx install poetry
 
@@ -44,7 +55,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.9"
+          python-version: "${{ env.PYTHON_VERSION }}"
           cache: poetry
 
       - name: Install Dependencies using Poetry
@@ -58,6 +69,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "${{ env.PYTHON_VERSION }}"
+
       - name: Install poetry
         run: pipx install poetry
 
@@ -66,7 +81,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.9"
+          python-version: "${{ env.PYTHON_VERSION }}"
           cache: poetry
 
       - name: Install dependencies

--- a/poetry_snakemake_plugin/templates/ci.yml.j2
+++ b/poetry_snakemake_plugin/templates/ci.yml.j2
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
+          python-version: {{ "${{ env.PYTHON_VERSION }}" }}
 
       - name: Install poetry
         run: pip install poetry
@@ -28,7 +28,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
+          python-version: {{ "${{ env.PYTHON_VERSION }}" }}
           cache: poetry
 
       - name: Install Dependencies using Poetry
@@ -45,7 +45,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
+          python-version: {{ "${{ env.PYTHON_VERSION }}" }}
 
       - name: Install poetry
         run: pip install poetry
@@ -55,7 +55,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
+          python-version: {{ "${{ env.PYTHON_VERSION }}" }}
           cache: poetry
 
       - name: Install Dependencies using Poetry
@@ -71,7 +71,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
+          python-version: {{ "${{ env.PYTHON_VERSION }}" }}
 
       - name: Install poetry
         run: pip install poetry
@@ -81,7 +81,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
+          python-version: {{ "${{ env.PYTHON_VERSION }}" }}
           cache: poetry
 
       - name: Install dependencies

--- a/poetry_snakemake_plugin/templates/ci.yml.j2
+++ b/poetry_snakemake_plugin/templates/ci.yml.j2
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: "${{ env.PYTHON_VERSION }}"
+          python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install poetry
         run: pip install poetry
@@ -28,7 +28,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: "${{ env.PYTHON_VERSION }}"
+          python-version: ${{ env.PYTHON_VERSION }}
           cache: poetry
 
       - name: Install Dependencies using Poetry
@@ -45,7 +45,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: "${{ env.PYTHON_VERSION }}"
+          python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install poetry
         run: pip install poetry
@@ -55,7 +55,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: "${{ env.PYTHON_VERSION }}"
+          python-version: ${{ env.PYTHON_VERSION }}
           cache: poetry
 
       - name: Install Dependencies using Poetry
@@ -71,7 +71,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: "${{ env.PYTHON_VERSION }}"
+          python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install poetry
         run: pip install poetry
@@ -81,7 +81,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: "${{ env.PYTHON_VERSION }}"
+          python-version: ${{ env.PYTHON_VERSION }}
           cache: poetry
 
       - name: Install dependencies

--- a/poetry_snakemake_plugin/templates/ci.yml.j2
+++ b/poetry_snakemake_plugin/templates/ci.yml.j2
@@ -6,12 +6,19 @@ on:
       - main
   pull_request:
 
+env:
+  PYTHON_VERSION: 3.11
+
 jobs:
   formatting:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the code
         uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "${{ env.PYTHON_VERSION }}"
 
       - name: Install poetry
         run: pipx install poetry
@@ -21,7 +28,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.9"
+          python-version: "${{ env.PYTHON_VERSION }}"
           cache: poetry
 
       - name: Install Dependencies using Poetry
@@ -36,6 +43,10 @@ jobs:
       - name: Check out the code
         uses: actions/checkout@v3
 
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "${{ env.PYTHON_VERSION }}"
+
       - name: Install poetry
         run: pipx install poetry
 
@@ -44,7 +55,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.9"
+          python-version: "${{ env.PYTHON_VERSION }}"
           cache: poetry
 
       - name: Install Dependencies using Poetry
@@ -58,6 +69,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "${{ env.PYTHON_VERSION }}"
+
       - name: Install poetry
         run: pipx install poetry
 
@@ -66,7 +81,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.9"
+          python-version: "${{ env.PYTHON_VERSION }}"
           cache: poetry
 
       - name: Install dependencies

--- a/poetry_snakemake_plugin/templates/release_please.yml.j2
+++ b/poetry_snakemake_plugin/templates/release_please.yml.j2
@@ -27,7 +27,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: "${{ env.PYTHON_VERSION }}"
 

--- a/poetry_snakemake_plugin/templates/release_please.yml.j2
+++ b/poetry_snakemake_plugin/templates/release_please.yml.j2
@@ -29,7 +29,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
+          python-version: {{ "${{ env.PYTHON_VERSION }}" }}
 
       - name: Install poetry
         run: pip install poetry
@@ -39,7 +39,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
+          python-version: {{ "${{ env.PYTHON_VERSION }}" }}
           cache: poetry
       
       - name: Install Dependencies using Poetry

--- a/poetry_snakemake_plugin/templates/release_please.yml.j2
+++ b/poetry_snakemake_plugin/templates/release_please.yml.j2
@@ -5,6 +5,9 @@ on:
 
 name: release-please
 
+env:
+  PYTHON_VERSION: 3.11
+
 jobs:
   release-please:
     runs-on: ubuntu-latest
@@ -26,7 +29,7 @@ jobs:
 
       - uses: actions/setup-python@v2
         with:
-          python-version: "3.9"
+          python-version: "${{ env.PYTHON_VERSION }}"
 
       - name: Install poetry
         run: pipx install poetry
@@ -36,7 +39,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.9"
+          python-version: "${{ env.PYTHON_VERSION }}"
           cache: poetry
 
       - name: Install Dependencies using Poetry

--- a/poetry_snakemake_plugin/templates/release_please.yml.j2
+++ b/poetry_snakemake_plugin/templates/release_please.yml.j2
@@ -29,7 +29,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: "${{ env.PYTHON_VERSION }}"
+          python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install poetry
         run: pip install poetry
@@ -39,7 +39,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: "${{ env.PYTHON_VERSION }}"
+          python-version: ${{ env.PYTHON_VERSION }}
           cache: poetry
       
       - name: Install Dependencies using Poetry


### PR DESCRIPTION
- python version as env var  in CI, and in scaffolds
- escaped in templates so jinja can rendr