### PR TITLE
fix: only include snakemake as a dev dependency if that is absolutely necessary

### DIFF
--- a/poetry_snakemake_plugin/common.py
+++ b/poetry_snakemake_plugin/common.py
@@ -17,6 +17,9 @@ class ScaffoldSnakemakePluginCommandBase(Command, ABC):
     def get_dependencies(self) -> List[str]:
         return [f"snakemake-interface-{self.get_plugin_type()}-plugins"]
 
+    @abstractmethod
+    def include_snakemake_dev_dependency(self) -> bool: ...
+
     def get_package_name_prefix(self) -> str:
         return f"snakemake-{self.get_plugin_type()}-plugin-"
 
@@ -49,18 +52,18 @@ class ScaffoldSnakemakePluginCommandBase(Command, ABC):
         sp.run(
             ["poetry", "add", "snakemake-interface-common"] + self.get_dependencies()
         )
-        sp.run(
-            [
-                "poetry",
-                "add",
-                "--group",
-                "dev",
-                "ruff",
-                "coverage",
-                "pytest",
-                "snakemake",
-            ]
-        )
+        dev_deps = [
+            "poetry",
+            "add",
+            "--group",
+            "dev",
+            "ruff",
+            "coverage",
+            "pytest",
+        ]
+        if self.include_snakemake_dev_dependency():
+            dev_deps.append("snakemake")
+        sp.run(dev_deps)
 
         # add skeleton code
         templates = Environment(

--- a/poetry_snakemake_plugin/executor_plugins.py
+++ b/poetry_snakemake_plugin/executor_plugins.py
@@ -19,3 +19,6 @@ class ScaffoldSnakemakeExecutorPluginCommand(ScaffoldSnakemakePluginCommandBase)
 
     def get_plugin_type(self) -> str:
         return "executor"
+
+    def include_snakemake_dev_dependency(self) -> bool:
+        return True

--- a/poetry_snakemake_plugin/report_plugins.py
+++ b/poetry_snakemake_plugin/report_plugins.py
@@ -19,3 +19,6 @@ class ScaffoldSnakemakeReportPluginCommand(ScaffoldSnakemakePluginCommandBase):
 
     def get_plugin_type(self) -> str:
         return "report"
+
+    def include_snakemake_dev_dependency(self) -> bool:
+        return True

--- a/poetry_snakemake_plugin/software_deployment_plugins.py
+++ b/poetry_snakemake_plugin/software_deployment_plugins.py
@@ -21,3 +21,6 @@ class ScaffoldSnakemakeSoftwareDeploymentPluginCommand(
 
     def get_plugin_type(self) -> str:
         return "software-deployment"
+
+    def include_snakemake_dev_dependency(self) -> bool:
+        return False

--- a/poetry_snakemake_plugin/storage_plugins.py
+++ b/poetry_snakemake_plugin/storage_plugins.py
@@ -19,3 +19,6 @@ class ScaffoldSnakemakeStoragePluginCommand(ScaffoldSnakemakePluginCommandBase):
 
     def get_plugin_type(self) -> str:
         return "storage"
+
+    def include_snakemake_dev_dependency(self) -> bool:
+        return False


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced development dependency management, allowing the platform to flexibly include or omit an additional tool based on context. This improvement optimizes the setup across various plugin areas without affecting existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->